### PR TITLE
Restructure the doc layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv/
 .DS_Store
 site/
 node_modules/
+.cache/

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: Welcome
+title: Overview
 icon: material/hand-wave-outline
 ---
 

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -13,18 +13,18 @@
 
 /**** Nav ****/
 
-.md-nav {
+/* .md-nav {
 	font-size: 0.8rem;
-}
+} */
 
 /*.md-nav__title {
 	display: none;
 }*/
 
-.md-nav__item {
+/* .md-nav__item {
 	padding: 0.3rem 0;
 	font-weight: bold;
-}
+} */
 
 .md-nav__link[href]:hover {
 	color: #ff6e42;

--- a/material/overrides/main.html
+++ b/material/overrides/main.html
@@ -8,7 +8,8 @@
 {% endblock %}
 
 <!-- Announcement bar -->
-{% block announce %}
+{% block announce___ %}
+
   For updates follow us on
   <span style="display: inline-block;">
     <a rel="me" href="https://mastodon.social/@DataRecce" target="_blank">
@@ -29,6 +30,7 @@
       <span class="twemoji linkedin">&nbsp;{% include ".icons/fontawesome/brands/linkedin.svg" %}&nbsp;</span>&nbsp;<strong>LinkedIn</strong>
     </a>
   </span>
+
 {% endblock %}
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Recce Documentation
+site_name: Recce
 site_description: >-
   Data change validation for dbt projects - 
   Create 'all signal, no noise' pull request comments
@@ -6,9 +6,7 @@ site_description: >-
 # Repository
 repo_name: datarecce/recce
 repo_url: https://github.com/datarecce/recce
-
 site_url: https://datarecce.io
-
 extra_css:
   - styles/extra.css
 
@@ -16,26 +14,42 @@ extra:
   analytics:
     provider: google
     property: G-E06MSTE2SX
-
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/DataRecce/recce
+    - icon: fontawesome/brands/slack
+      link: https://getdbt.slack.com/archives/C05C28V7CPP      
+    - icon: fontawesome/brands/x-twitter
+      link: https://x.com/datarecce
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/company/datarecce
+    - icon: fontawesome/brands/mastodon 
+      link: https://mastodon.social/@DataRecce
 nav:
   - index.md
-  - blog/index.md
-  - docs/index.md
-  - docs/installation.md
-  - docs/get-started.md
-  - docs/demo.md
-  - Features:
-    - docs/features/checklist.md
-    - docs/features/histogram-diff.md
-    - docs/features/lineage-diff.md
-    - docs/features/profile-diff.md
-    - docs/features/query-diff.md
-    - docs/features/row-count-diff.md
-    - docs/features/schema-diff.md
-    - docs/features/top-k-diff.md
-    - docs/features/value-diff.md
+  - Overview:
+    - docs/index.md
+    - docs/demo.md
+  
+  - Guides:
+    - Getting Started:
+      - docs/get-started.md
+      - docs/installation.md  
+    - Lineage:
+      - docs/features/lineage-diff.md
+      - docs/features/row-count-diff.md
+      - docs/features/schema-diff.md      
+      - docs/features/value-diff.md      
+      - docs/features/profile-diff.md
+      - docs/features/top-k-diff.md
+      - docs/features/histogram-diff.md
+              
+    - Query:
+      - docs/features/query-diff.md        
+    - Checklist:
+      - docs/features/checklist.md
     
-
+  - Blog: 'https://medium.com/inthepipeline'
   #- Recce Blog:
     #- blog/index.md
 
@@ -80,9 +94,9 @@ theme:
   features:
     # - navigation.instant
     # - navigation.instant.progress
-    # - navigation.tabs
+    - navigation.tabs
     - navigation.sections
-    - content.code.copy
+    - content.code.copy  
 
 plugins:
   - search


### PR DESCRIPTION
1. Add the top navigation 
2. Remove the announcement header, move the social links to the footer.
3. Adjust the nav item css.
4. Reorg the nav tree.
5. Change the blog link to https://medium.com/inthepipeline

Before
<img width="1388" alt="image" src="https://github.com/DataRecce/recce-documentation/assets/860633/f552b964-d273-4c5a-84b1-df0ede7865c5">


After
<img width="1365" alt="image" src="https://github.com/DataRecce/recce-documentation/assets/860633/9e19b407-1243-481e-b909-48f5ac2da497">
