### PR TITLE
[DRC-598] Update the recce server to instance

### DIFF
--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -52,7 +52,7 @@ A run documents a single execution of a Task, capturing details such as the type
     --data-raw '{}'
     ```
 
-In the recce instance, each run is recorded, so in theory, it is possible to access the run history. However, the current UI does not offer this feature. You can see the complete run history from the exported recce state.
+In the Recce instance, each run is recorded, so in theory, it is possible to access the run history. However, the current UI does not offer this feature. You can see the complete run history from the exported recce state.
 
 
 ### Checks

--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -52,7 +52,7 @@ A run documents a single execution of a Task, capturing details such as the type
     --data-raw '{}'
     ```
 
-In the recce server, each run is recorded, so in theory, it is possible to access the run history. However, the current UI does not offer this feature. You can see the complete run history from the exported recce state.
+In the recce instance, each run is recorded, so in theory, it is possible to access the run history. However, the current UI does not offer this feature. You can see the complete run history from the exported recce state.
 
 
 ### Checks

--- a/docs/docs/features/preset-checks.md
+++ b/docs/docs/features/preset-checks.md
@@ -5,7 +5,7 @@ icon: material/playlist-check
 
 In a dbt project, there may be some checks that need to be conducted for every PR. For example, this could be an SQL query, or checking whether an important model has had a schema change.
 
-Preset checks can be the fixed checks that are generated every time a new recce server is initiated.
+Preset checks can be the fixed checks that are generated every time a new recce instance is initiated.
 
 
 ## Configure the Preset Check
@@ -41,7 +41,7 @@ To configure the preset checks, add the settings to the [recce config file](../r
 
 ### Recce Server
 
-1. When a new recce server is launched, all preset checks are automatically set up, but these checks are not executed at this time.
+1. When a new recce server instance is launched, all preset checks are automatically set up, but these checks are not executed at this time.
     ![alt text](../../assets/images/features/preset-checks.png){: .shadow}
 2. When the **Run Query** button is pressed, the check will be executed.
 

--- a/docs/docs/features/preset-checks.md
+++ b/docs/docs/features/preset-checks.md
@@ -5,7 +5,7 @@ icon: material/playlist-check
 
 In a dbt project, there may be some checks that need to be conducted for every PR. For example, this could be an SQL query, or checking whether an important model has had a schema change.
 
-Preset checks can be the fixed checks that are generated every time a new recce instance is initiated.
+Preset checks can be the fixed checks that are generated every time a new Recce instance is initiated.
 
 
 ## Configure the Preset Check
@@ -41,7 +41,7 @@ To configure the preset checks, add the settings to the [recce config file](../r
 
 ### Recce Server
 
-1. When a new recce server instance is launched, all preset checks are automatically set up, but these checks are not executed at this time.
+1. When a new Recce instance is launched, all preset checks are automatically set up, but these checks are not executed at this time.
     ![alt text](../../assets/images/features/preset-checks.png){: .shadow}
 2. When the **Run Query** button is pressed, the check will be executed.
 

--- a/docs/docs/features/state-file.md
+++ b/docs/docs/features/state-file.md
@@ -38,7 +38,7 @@ To review a PR, you can download the corresponding state file and open the file 
 recce server --review recce_state.json
 ```
 
-In this mode, the Recce server won't use the dbt artifacts inside `target` and `target-base`. Instead, it will use the artifacts from the Recce state file.
+In this mode, the Recce instance won't use the dbt artifacts inside `target` and `target-base`. Instead, it will use the artifacts from the Recce state file.
 
 ## Development
 

--- a/docs/docs/guides/scenario-dev.md
+++ b/docs/docs/guides/scenario-dev.md
@@ -105,5 +105,5 @@ Another technique is to specify the file directly when opening it.
 recce server recce_issue_123.json
 ```
 
-When you close the Recce server instance, it saves your current session to this file. The next time you open it using the same file, it will restore to the previous state.
+When you close the Recce instance, it saves your current session to this file. The next time you open it using the same file, it will restore to the previous state.
 

--- a/docs/docs/recce-cloud/getting-started-recce-cloud.md
+++ b/docs/docs/recce-cloud/getting-started-recce-cloud.md
@@ -152,7 +152,7 @@ As a PR author, you can prepare the recce review state and persist it in the rec
    export GITHUB_TOKEN=<github-token>
    export RECCE_STATE_PASSWORD=mypassword
    ```
-1. Run recce server in the cloud mode
+1. Run recce server instance in the cloud mode
    ```
    recce server --cloud
    ```
@@ -165,7 +165,7 @@ As a PR author, you can prepare the recce review state and persist it in the rec
    ![alt text](../../assets/images/recce-cloud/query-diff.png){: .shadow}
 1. Click the `+` button to add the query result to checklist
 1. You can find that there are three checks in the **Checks** page
-1. Terminate the server. It would store the state to the recce cloud.
+1. Terminate the recce instance. It would store the state to the recce cloud.
 1. In the GitHub PR page, we can find a failed check for this PR. This is because not all checks are approved.
    ![alt text](../../assets/images/recce-cloud/pr-checks-wo-approved.png){: .shadow}
 

--- a/docs/docs/recce-cloud/getting-started-recce-cloud.md
+++ b/docs/docs/recce-cloud/getting-started-recce-cloud.md
@@ -152,7 +152,7 @@ As a PR author, you can prepare the recce review state and persist it in the rec
    export GITHUB_TOKEN=<github-token>
    export RECCE_STATE_PASSWORD=mypassword
    ```
-1. Run recce server instance in the cloud mode
+1. Run Recce instance in the cloud mode
    ```
    recce server --cloud
    ```
@@ -165,7 +165,7 @@ As a PR author, you can prepare the recce review state and persist it in the rec
    ![alt text](../../assets/images/recce-cloud/query-diff.png){: .shadow}
 1. Click the `+` button to add the query result to checklist
 1. You can find that there are three checks in the **Checks** page
-1. Terminate the recce instance. It would store the state to the recce cloud.
+1. Terminate the Recce instance. It would store the state to the recce cloud.
 1. In the GitHub PR page, we can find a failed check for this PR. This is because not all checks are approved.
    ![alt text](../../assets/images/recce-cloud/pr-checks-wo-approved.png){: .shadow}
 

--- a/docs/docs/recce-cloud/index.md
+++ b/docs/docs/recce-cloud/index.md
@@ -45,7 +45,7 @@ The following instructions give an overview of the process of using Recce in you
    ```
 1. Develop your features and prepare the dbt artifacts for the base (`target-base/`) and current (`target/`) environments.
 1. Create a pull request for this branch. Recce Cloud requires an open pull request in your GitHub repository. It also stores the latest Recce state for each pull request.
-1. Launch the recce server in the cloud mode. It will use the dbt artifacts in the local `target` and `target-base` and initiate a new review state if necessary.
+1. Launch the recce server instance in the cloud mode. It will use the dbt artifacts in the local `target` and `target-base` and initiate a new review state if necessary.
    ```
    recce server --cloud
    ```
@@ -56,10 +56,10 @@ The following instructions give an overview of the process of using Recce in you
 
 
 ### Review in the cloud mode
-If the review state is already available for this PR, you can open the recce server to review.
+If the review state is already available for this PR, you can open the recce instance to review.
 
 1. Checkout the branch for the reviewed PR.
-1. Launch the recce server to review this PR
+1. Launch the recce instance to review this PR
     ```
     recce server --review --cloud
     ```

--- a/docs/docs/recce-cloud/index.md
+++ b/docs/docs/recce-cloud/index.md
@@ -45,7 +45,7 @@ The following instructions give an overview of the process of using Recce in you
    ```
 1. Develop your features and prepare the dbt artifacts for the base (`target-base/`) and current (`target/`) environments.
 1. Create a pull request for this branch. Recce Cloud requires an open pull request in your GitHub repository. It also stores the latest Recce state for each pull request.
-1. Launch the recce server instance in the cloud mode. It will use the dbt artifacts in the local `target` and `target-base` and initiate a new review state if necessary.
+1. Launch the Recce instance in the cloud mode. It will use the dbt artifacts in the local `target` and `target-base` and initiate a new review state if necessary.
    ```
    recce server --cloud
    ```
@@ -56,10 +56,10 @@ The following instructions give an overview of the process of using Recce in you
 
 
 ### Review in the cloud mode
-If the review state is already available for this PR, you can open the recce instance to review.
+If the review state is already available for this PR, you can open the Recce instance to review.
 
 1. Checkout the branch for the reviewed PR.
-1. Launch the recce instance to review this PR
+1. Launch the Recce instance to review this PR
     ```
     recce server --review --cloud
     ```

--- a/docs/docs/recce-cloud/setup-gh-codespaces.md
+++ b/docs/docs/recce-cloud/setup-gh-codespaces.md
@@ -7,7 +7,7 @@ icon: octicons/codespaces-16
 
     Recce Cloud is currently in **private alpha** and scheduled for general availability later this year.  [Sign up](../../cloud.md#signup) to the Recce newsletter to be notified, or email [product@datarecce.io](mailto:product@datarecce.io) to join our design partnership program for early access.
 
-GitHub Codespaces is a development environment provided by GitHub that allows developers to have identical and isolated environments for development. The GitHub Codespaces uses VS Code Server technology. We can launch it from a GitHub pull request page, and once it is started, the Recce server will run and port forwarding will be set up.
+GitHub Codespaces is a development environment provided by GitHub that allows developers to have identical and isolated environments for development. The GitHub Codespaces uses VS Code Server technology. We can launch it from a GitHub pull request page, and once it is started, the Recce instance will run and port forwarding will be set up.
 
 ## Setup Recce Cloud in GitHub Codespaces
 
@@ -54,7 +54,7 @@ Here, we [use GitHub Codespaces for pull requests](https://docs.github.com/en/co
 1. Click the **Code** button and create a Codespace on the PR branch
    ![alt text](../../assets/images/recce-cloud/setup-codespaces-pr.png){: .shadow}
 1. Starting a Codespace instance usually takes one to several minutes.
-1. When the Recce server starts, an **Open Browser** notification will appear. Click the button to open the Recce web UI in a new tab.
+1. When the Recce instance starts, an **Open Browser** notification will appear. Click the button to open the Recce web UI in a new tab.
 1. Or you can go to the **PORTS** tab to open the page.
 
 
@@ -72,7 +72,7 @@ Codespace offers a [prebuild](https://docs.github.com/en/codespaces/prebuilding-
 
 **Q: Can a Codespace environment be shared? Can different people access the same Codespace instance?**
 
-A Codespace environment is tied to each individual GitHub user account. Therefore, a Codespace instance opened by User A cannot be directly accessed by User B. However, User A can set a specific port to be public and [share the URL with others](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port). However, the server is still running under User A's account.
+A Codespace environment is tied to each individual GitHub user account. Therefore, a Codespace instance opened by User A cannot be directly accessed by User B. However, User A can set a specific port to be public and [share the URL with others](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace#sharing-a-port). However, the instance is still running under User A's account.
 
 **Q: Personal Codespace vs. Organization Codespace? How is Codespace billed?**
 

--- a/readme.md
+++ b/readme.md
@@ -83,3 +83,4 @@ Try to keep animated gifs no bigger than around 1MB. Only use multiple large gif
 
 
 
+sasfsdfsdf

--- a/readme.md
+++ b/readme.md
@@ -83,4 +83,3 @@ Try to keep animated gifs no bigger than around 1MB. Only use multiple large gif
 
 
 
-sasfsdfsdf


### PR DESCRIPTION
Review and change some wording from `recce server` and `recce instance`. 

- If the context is describing a recce server instance in the cloud, we will use "recce instance." 
- If it's about executing the recce server command, we will use "recce server."


