### PR TITLE
Fixing minor home page typo

### DIFF
--- a/material/overrides/home.html
+++ b/material/overrides/home.html
@@ -355,7 +355,7 @@
             <div class="feature-details">
                <span class="section-tag">Low Level Checks</span>
                <h2 class="feature-title">Granular Spot-Checks</h2>
-               <p>See row-level data change for precise validation and rook cause analysis.</p>
+               <p>See row-level data change for precise validation and root cause analysis.</p>
                <p><a href="/docs/features/query/">Read the documentation &gt;</a></p>
 
             </div>


### PR DESCRIPTION
Changes "rook cause" to "root cause"