### PR TITLE
Adding Vector.co tracking pixel to website

### DIFF
--- a/material/overrides/main.html
+++ b/material/overrides/main.html
@@ -5,6 +5,12 @@
 
   <!-- Extra style sheets (can't be set in mkdocs.yml due to content hash) -->
   
+  <!-- Vector Analytics Tracking Code -->
+  <script>
+    !function(e,r){try{if(e.vector)return void console.log("Vector snippet included more than once.");var t={};t.q=t.q||[];for(var o=["load","identify","on"],n=function(e){return function(){var r=Array.prototype.slice.call(arguments);t.q.push([e,r])}},c=0;c<o.length;c++){var a=o[c];t[a]=n(a)}if(e.vector=t,!t.loaded){var i=r.createElement("script");i.type="text/javascript",i.async=!0,i.src="https://cdn.vector.co/pixel.js";var l=r.getElementsByTagName("script")[0];l.parentNode.insertBefore(i,l),t.loaded=!0}}catch(e){console.error("Error loading Vector:",e)}}(window,document);
+    vector.load("fa95ac47-4404-4484-97bc-706ad77c5e37");
+  </script>
+
 {% endblock %}
 
 <!-- Announcement bar -->
@@ -41,4 +47,3 @@
   <!-- Extra JavaScript (can't be set in mkdocs.yml due to content hash) -->
   <script src="{{ 'assets/js/custom.js' | url }}"></script>
 {% endblock %}
-


### PR DESCRIPTION
This code adds the Vector.co <https://www.vector.co/> to the website in the header. This should make it such that we can deanon traffic. This will only be for US traffic and doesn't require an updated to our privacy docs.